### PR TITLE
introduce a ProxyHolder class

### DIFF
--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -29,22 +29,3 @@ part "src/workspace.dart";
 
 js.JsObject require(String input) => js.context.callMethod("require", [input]);
 js.JsObject get global => js.context;
-
-js.JsObject jsify(Map map) => new js.JsObject.jsify(map);
-
-abstract class ProxyHolder extends Object {
-  final js.JsObject obj;
-  ProxyHolder(this.obj);
-
-  dynamic invoke(String method, [dynamic arg1, dynamic arg2, dynamic arg3]) {
-    if (arg3 != null) {
-      return obj.callMethod(method, [arg1, arg2, arg3]);
-    } else if (arg2 != null) {
-      return obj.callMethod(method, [arg1, arg2]);
-    } else if (arg2 != null) {
-      return obj.callMethod(method, [arg1]);
-    } else {
-      return obj.callMethod(method);
-    }
-  }
-}

--- a/lib/atom.dart
+++ b/lib/atom.dart
@@ -8,28 +8,43 @@ import "dart:js" as js;
 
 import "utils.dart";
 
-part "src/core.dart";
+part "src/color.dart";
 part "src/command_registry.dart";
 part "src/config.dart";
-part "src/text_editor.dart";
-part "src/workspace.dart";
-part "src/packages.dart";
-part "src/themes.dart";
-part "src/styles.dart";
+part "src/core.dart";
+part "src/grammars.dart";
+part "src/keymap.dart";
 part "src/menu.dart";
 part "src/notification_manager.dart";
-part "src/grammars.dart";
-part "src/tooltips.dart";
-part "src/project.dart";
-part "src/panel.dart";
+part "src/packages.dart";
 part "src/pane.dart";
-part "src/color.dart";
-part "src/keymap.dart";
+part "src/panel.dart";
 part "src/process.dart";
+part "src/project.dart";
+part "src/styles.dart";
+part "src/text_editor.dart";
+part "src/themes.dart";
+part "src/tooltips.dart";
+part "src/workspace.dart";
 
 js.JsObject require(String input) => js.context.callMethod("require", [input]);
 js.JsObject get global => js.context;
 
-js.JsObject toJsObject(Map map) {
-  return new js.JsObject.jsify(map);
+js.JsObject jsify(Map map) => new js.JsObject.jsify(map);
+
+abstract class ProxyHolder extends Object {
+  final js.JsObject obj;
+  ProxyHolder(this.obj);
+
+  dynamic invoke(String method, [dynamic arg1, dynamic arg2, dynamic arg3]) {
+    if (arg3 != null) {
+      return obj.callMethod(method, [arg1, arg2, arg3]);
+    } else if (arg2 != null) {
+      return obj.callMethod(method, [arg1, arg2]);
+    } else if (arg2 != null) {
+      return obj.callMethod(method, [arg1]);
+    } else {
+      return obj.callMethod(method);
+    }
+  }
 }

--- a/lib/build.dart
+++ b/lib/build.dart
@@ -31,13 +31,12 @@ main(List<String> args) async {
 
 findScripts() async {
   var dir = new Directory(options.scriptScanDirectory);
-  scripts.addAll(
-    await dir.list(recursive: true)
+  scripts.addAll(await dir
+      .list(recursive: true)
       .where((it) => it is File && it.path.endsWith(".dart"))
       .map((it) => it.path.replaceAll(dir.parent.path + "/", ""))
       .where((it) => !it.contains("packages/"))
-      .toList()
-  );
+      .toList());
 
   var a = [];
   for (var p in scripts) {
@@ -90,7 +89,8 @@ compile() async {
   for (var script in scripts) {
     var js = getJsName(script);
     print("[Compile] ${script}");
-    await exec("${Platform.isWindows ? 'dart2js.bat' : 'dart2js'} --csp -o ${js} ${script}");
+    await exec(
+        "${Platform.isWindows ? 'dart2js.bat' : 'dart2js'} --csp -o ${js} ${script}");
     var file = new File(js);
     var content = await file.readAsString();
     content = fixScript(content);
@@ -115,15 +115,11 @@ exec(String command) async {
 String getJsName(String file) => file.replaceAll(".dart", ".js");
 
 cleanup({bool includeScripts: false}) async {
-  var files = scripts
-    .map(getJsName)
-    .expand((it) =>
-      ["${it}.deps"]
-        ..addAll(includeScripts ? [it] : [])
-        ..addAll((includeScripts && !isDevEnabled) ? ["${it}.map"] : [])
-    );
+  var files = scripts.map(getJsName).expand((it) => ["${it}.deps"]
+    ..addAll(includeScripts ? [it] : [])
+    ..addAll((includeScripts && !isDevEnabled) ? ["${it}.map"] : []));
   for (var name in files) {
-    var file =  new File(name);
+    var file = new File(name);
     if (await file.exists()) {
       await file.delete();
     }
@@ -140,7 +136,10 @@ runPackageScript() async {
 }
 
 String fixScript(String input) {
-  return HEADER + "\n" + input.replaceAll(r'if (typeof document === "undefined") {', "if (true) {");
+  return HEADER +
+      "\n" +
+      input.replaceAll(
+          r'if (typeof document === "undefined") {', "if (true) {");
 }
 
 final String HEADER = """

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -17,8 +17,13 @@ class Menu {
 
   String command;
 
-  Menu(this.label) : submenus = [], contextMenu = false, selector = null;
-  Menu.root(this.label, {this.contextMenu: false, this.selector}) : _root = true, submenus = [];
+  Menu(this.label)
+      : submenus = [],
+        contextMenu = false,
+        selector = null;
+  Menu.root(this.label, {this.contextMenu: false, this.selector})
+      : _root = true,
+        submenus = [];
 
   void addSubMenu(Menu menu) {
     submenus.add(menu);
@@ -50,20 +55,14 @@ class Menu {
     if (isRoot) {
       if (contextMenu) {
         return {
-          "context-menu": {
-            selector: submenus.map((it) => it.toJSON()).toList()
-          }
+          "context-menu": {selector: submenus.map((it) => it.toJSON()).toList()}
         };
       } else {
-        return {
-          "menu": submenus.map((it) => it.toJSON()).toList()
-        };
+        return {"menu": submenus.map((it) => it.toJSON()).toList()};
       }
     }
 
-    var map = {
-      "label": label
-    };
+    var map = {"label": label};
 
     if (command != null) {
       map["command"] = command;
@@ -92,7 +91,8 @@ class KeyMap {
     return this;
   }
 
-  KeyMap add(String block, String key, String command) => map(block, key, command);
+  KeyMap add(String block, String key, String command) =>
+      map(block, key, command);
 
   Map toJSON() => mappings;
 }
@@ -115,7 +115,8 @@ class Stylesheet {
       buff.writeln("${block.selector} {");
       var str = block.build();
 
-      buff.writeln((str.isNotEmpty ? "  " : "") + str.split("\n").map((it) => "  ${it}").join("\n").trim());
+      buff.writeln((str.isNotEmpty ? "  " : "") +
+          str.split("\n").map((it) => "  ${it}").join("\n").trim());
       buff.writeln("}");
     }
     return buff.toString();
@@ -146,7 +147,8 @@ class StyleBlock {
       buff.writeln("${block.selector} {");
       var str = block.build();
 
-      buff.writeln((str.isNotEmpty ? "  " : "") + str.split("\n").map((it) => "  ${it}").join("\n"));
+      buff.writeln((str.isNotEmpty ? "  " : "") +
+          str.split("\n").map((it) => "  ${it}").join("\n"));
       buff.writeln("}");
     }
 
@@ -236,7 +238,8 @@ class Package {
 Package _package;
 List<Grammar> _grammars = [];
 
-Package package(String name, String version, {String main, String license, String repository, String description}) {
+Package package(String name, String version,
+    {String main, String license, String repository, String description}) {
   var m = new Package(name, version);
 
   if (main != null) {
@@ -263,13 +266,15 @@ void build() {
   for (var m in _menuFiles) {
     var file = new File("menus/${m.label}.json");
     file.createSync(recursive: true);
-    file.writeAsStringSync(new JsonEncoder.withIndent("  ").convert(m.toJSON()));
+    file.writeAsStringSync(
+        new JsonEncoder.withIndent("  ").convert(m.toJSON()));
   }
 
   for (var m in _keymaps) {
     var file = new File("keymaps/${m.name}.json");
     file.createSync(recursive: true);
-    file.writeAsStringSync(new JsonEncoder.withIndent("  ").convert(m.toJSON()));
+    file.writeAsStringSync(
+        new JsonEncoder.withIndent("  ").convert(m.toJSON()));
   }
 
   for (var m in _stylesheets) {
@@ -281,7 +286,8 @@ void build() {
   for (var m in _grammars) {
     var file = new File("grammars/${m.name}.json");
     file.createSync(recursive: true);
-    file.writeAsStringSync(new JsonEncoder.withIndent("  ").convert(m.toJSON()));
+    file.writeAsStringSync(
+        new JsonEncoder.withIndent("  ").convert(m.toJSON()));
   }
 
   if (_package != null) {
@@ -304,8 +310,10 @@ class Grammar {
     return this;
   }
 
-  void load(void handler(void match(String name, String pattern), void beginEnd(name, String begin, String end, [patterns]))) {
-    handler((name, p) => pattern(new MatchGrammarPattern(name, p)), (name, begin, end, [patterns]) {
+  void load(void handler(void match(String name, String pattern),
+      void beginEnd(name, String begin, String end, [patterns]))) {
+    handler((name, p) => pattern(new MatchGrammarPattern(name, p)),
+        (name, begin, end, [patterns]) {
       pattern(new BeginEndGrammarPattern(name, begin, end, patterns));
     });
   }
@@ -335,10 +343,7 @@ class MatchGrammarPattern extends GrammarPattern {
   MatchGrammarPattern(this.name, this.match);
 
   @override
-  Map toJSON() => {
-    "name": name,
-    "match": match
-  };
+  Map toJSON() => {"name": name, "match": match};
 }
 
 class BeginEndGrammarPattern extends GrammarPattern {
@@ -351,11 +356,7 @@ class BeginEndGrammarPattern extends GrammarPattern {
 
   @override
   Map toJSON() {
-    var map = {
-      "name": name,
-      "begin": begin,
-      "end": end
-    };
+    var map = {"name": name, "begin": begin, "end": end};
 
     if (patterns != null) {
       map["patterns"] = patterns.map((it) => it.toJSON()).toList();

--- a/lib/src/color.dart
+++ b/lib/src/color.dart
@@ -1,7 +1,8 @@
 part of atom;
 
 class Color {
-  static Color parse(String input) => new Color(global["Color"].callMethod("parse"));
+  static Color parse(String input) =>
+      new Color(global["Color"].callMethod("parse"));
 
   final js.JsObject obj;
 

--- a/lib/src/color.dart
+++ b/lib/src/color.dart
@@ -1,15 +1,13 @@
 part of atom;
 
-class Color {
+class Color extends ProxyHolder {
   static Color parse(String input) =>
       new Color(global["Color"].callMethod("parse"));
 
-  final js.JsObject obj;
+  Color(js.JsObject obj) : super(obj);
 
-  Color(this.obj);
-
-  String toHexString() => obj.callMethod("toHexString");
-  String toRGBAString() => obj.callMethod("toRGBAString");
+  String toHexString() => invoke("toHexString");
+  String toRGBAString() => invoke("toRGBAString");
 
   int get red => obj["red"];
   int get green => obj["green"];

--- a/lib/src/command_registry.dart
+++ b/lib/src/command_registry.dart
@@ -1,11 +1,9 @@
 part of atom;
 
-class CommandRegistry {
-  final js.JsObject o;
-
-  CommandRegistry(this.o);
+class CommandRegistry extends ProxyHolder {
+  CommandRegistry(js.JsObject obj) : super(obj);
 
   Disposable add(String target, String command, void callback(event)) {
-    return new Disposable(o.callMethod("add", [target, command, callback]));
+    return new Disposable(invoke("add", target, command, callback));
   }
 }

--- a/lib/src/command_registry.dart
+++ b/lib/src/command_registry.dart
@@ -6,12 +6,6 @@ class CommandRegistry {
   CommandRegistry(this.o);
 
   Disposable add(String target, String command, void callback(event)) {
-    return new Disposable(
-      o.callMethod("add", [
-        target,
-        command,
-        callback
-      ])
-    );
+    return new Disposable(o.callMethod("add", [target, command, callback]));
   }
 }

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -4,27 +4,26 @@ class Config extends ProxyHolder {
   Config(js.JsObject obj) : super(obj);
 
   dynamic get(String key, {dynamic defaultValue, List<String> sources,
-      List<String> excludeSources, ScopeDescriptor scope}) => invoke(
-          "get",
-    key,
-    defaultValue,
-    {"sources": sources, "excludeSources": excludeSources, "scope": scope.obj}
-  );
+      List<String> excludeSources, ScopeDescriptor scope}) => invoke("get", key,
+          defaultValue, {
+    "sources": sources,
+    "excludeSources": excludeSources,
+    "scope": scope.obj
+  });
 
   void set(String key, dynamic value, {String scopeSelector, String source}) =>
-      invoke("set",
-    key,
-    value,
-    {"scopeSelector": scopeSelector, "source": source}
-  );
+      invoke("set", key, value, {
+    "scopeSelector": scopeSelector,
+    "source": source
+  });
 
-  void unset(String key, {String scopeSelector, String source}) => invoke(
-          "unset", key, {"scopeSelector": scopeSelector, "source": source});
+  void unset(String key, {String scopeSelector, String source}) =>
+      invoke("unset", key, {"scopeSelector": scopeSelector, "source": source});
 }
 
 class ScopeDescriptor extends ProxyHolder {
-  ScopeDescriptor(List<String> scopes) : super(global.callMethod(
-          "ScopeDescriptor", [new js.JsArray.from(scopes)]));
+  ScopeDescriptor(List<String> scopes) : super(
+          global.callMethod("ScopeDescriptor", [new js.JsArray.from(scopes)]));
   ScopeDescriptor.wrap(js.JsObject obj) : super(obj);
 
   List<String> get scopes => invoke("getScopesArray");

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -1,36 +1,31 @@
 part of atom;
 
-class Config {
-  final js.JsObject obj;
-
-  Config(this.obj);
+class Config extends ProxyHolder {
+  Config(js.JsObject obj) : super(obj);
 
   dynamic get(String key, {dynamic defaultValue, List<String> sources,
-      List<String> excludeSources, ScopeDescriptor scope}) => obj.callMethod(
-          "get", [
+      List<String> excludeSources, ScopeDescriptor scope}) => invoke(
+          "get",
     key,
     defaultValue,
     {"sources": sources, "excludeSources": excludeSources, "scope": scope.obj}
-  ]);
+  );
 
   void set(String key, dynamic value, {String scopeSelector, String source}) =>
-      obj.callMethod("set", [
+      invoke("set",
     key,
     value,
     {"scopeSelector": scopeSelector, "source": source}
-  ]);
+  );
 
-  void unset(String key, {String scopeSelector, String source}) => obj
-      .callMethod(
-          "unset", [key, {"scopeSelector": scopeSelector, "source": source}]);
+  void unset(String key, {String scopeSelector, String source}) => invoke(
+          "unset", key, {"scopeSelector": scopeSelector, "source": source});
 }
 
-class ScopeDescriptor {
-  final js.JsObject obj;
+class ScopeDescriptor extends ProxyHolder {
+  ScopeDescriptor(List<String> scopes) : super(global.callMethod(
+          "ScopeDescriptor", [new js.JsArray.from(scopes)]));
+  ScopeDescriptor.wrap(js.JsObject obj) : super(obj);
 
-  ScopeDescriptor(List<String> scopes) : obj = global.callMethod(
-          "ScopeDescriptor", [new js.JsArray.from(scopes)]);
-  ScopeDescriptor.wrap(this.obj);
-
-  List<String> get scopes => obj.callMethod("getScopesArray");
+  List<String> get scopes => invoke("getScopesArray");
 }

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -5,31 +5,31 @@ class Config {
 
   Config(this.obj);
 
-  dynamic get(String key, {dynamic defaultValue, List<String> sources, List<String> excludeSources, ScopeDescriptor scope}) =>
-    obj.callMethod("get", [key, defaultValue, {
-      "sources": sources,
-      "excludeSources": excludeSources,
-      "scope": scope.obj
-    }]);
+  dynamic get(String key, {dynamic defaultValue, List<String> sources,
+      List<String> excludeSources, ScopeDescriptor scope}) => obj.callMethod(
+          "get", [
+    key,
+    defaultValue,
+    {"sources": sources, "excludeSources": excludeSources, "scope": scope.obj}
+  ]);
 
   void set(String key, dynamic value, {String scopeSelector, String source}) =>
-    obj.callMethod("set", [key, value, {
-      "scopeSelector": scopeSelector,
-      "source": source
-    }]);
+      obj.callMethod("set", [
+    key,
+    value,
+    {"scopeSelector": scopeSelector, "source": source}
+  ]);
 
-  void unset(String key, {String scopeSelector, String source}) =>
-    obj.callMethod("unset", [key, {
-      "scopeSelector": scopeSelector,
-      "source": source
-    }]);
+  void unset(String key, {String scopeSelector, String source}) => obj
+      .callMethod(
+          "unset", [key, {"scopeSelector": scopeSelector, "source": source}]);
 }
 
 class ScopeDescriptor {
   final js.JsObject obj;
 
-  ScopeDescriptor(List<String> scopes) :
-    obj = global.callMethod("ScopeDescriptor", [new js.JsArray.from(scopes)]);
+  ScopeDescriptor(List<String> scopes) : obj = global.callMethod(
+          "ScopeDescriptor", [new js.JsArray.from(scopes)]);
   ScopeDescriptor.wrap(this.obj);
 
   List<String> get scopes => obj.callMethod("getScopesArray");

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -41,12 +41,8 @@ void onPackageDeactivated(Action action) {
   _onDeactivate.add(action);
 }
 
-class ModuleExports {
-  js.JsObject obj;
-
-  ModuleExports() {
-    obj = global["module"]["exports"];
-  }
+class ModuleExports extends ProxyHolder {
+  ModuleExports() : super(global["module"]["exports"]);
 
   Function get activate => obj["activate"];
   set activate(Function function) {
@@ -84,35 +80,29 @@ class ClipboardContent {
   ClipboardContent(this.text, this.metadata);
 }
 
-class Clipboard {
-  final js.JsObject obj;
+class Clipboard extends ProxyHolder {
+  Clipboard(js.JsObject obj) : super(obj);
 
-  Clipboard(this.obj);
-
-  String read() => obj.callMethod("read");
+  String read() => invoke("read");
   ClipboardContent readWithMetadata() =>
       new ClipboardContent(obj["text"], obj["metadata"]);
 
   void write(String text, [Map metadata = const {}]) {
-    var j = jsify(metadata);
-
-    obj.callMethod("write", [text, j]);
+    invoke("write", text, metadata);
   }
 }
 
-class Atom {
-  static final js.JsObject o = js.context["atom"];
-
-  Atom() {
-    workspace = new Workspace(o["workspace"]);
-    commands = new CommandRegistry(o["commands"]);
-    packages = new PackageManager(o["packages"]);
-    styles = new StyleManager(o["styles"]);
-    themes = new ThemeManager(o["themes"]);
-    menu = new MenuManager(o["menu"]);
-    clipboard = new Clipboard(o["clipboard"]);
-    contextMenu = new ContextMenuManager(o["contextMenu"]);
-    tooltips = new TooltipManager(o["tooltips"]);
+class Atom extends ProxyHolder {
+  Atom() : super(global["atom"]) {
+    workspace = new Workspace(obj["workspace"]);
+    commands = new CommandRegistry(obj["commands"]);
+    packages = new PackageManager(obj["packages"]);
+    styles = new StyleManager(obj["styles"]);
+    themes = new ThemeManager(obj["themes"]);
+    menu = new MenuManager(obj["menu"]);
+    clipboard = new Clipboard(obj["clipboard"]);
+    contextMenu = new ContextMenuManager(obj["contextMenu"]);
+    tooltips = new TooltipManager(obj["tooltips"]);
   }
 
   Workspace workspace;
@@ -124,9 +114,9 @@ class Atom {
   Clipboard clipboard;
   ContextMenuManager contextMenu;
   TooltipManager tooltips;
-  Project get project => new Project(o["project"]);
+  Project get project => new Project(obj["project"]);
   NotificationManager get notifications =>
-      new NotificationManager(o['notifications']);
+      new NotificationManager(obj['notifications']);
 
   void open(List<String> paths, {bool newWindow, bool devMode, bool safeMode}) {
     var opts = omap({
@@ -136,32 +126,28 @@ class Atom {
       "safeMode": safeMode
     });
 
-    o.callMethod("open", [opts]);
+    invoke("open", opts);
   }
 
-  void reopenItem() => o.callMethod("reopenItem");
+  void reopenItem() => invoke("reopenItem");
 
   Disposable onDidBeep(Action callback) {
-    return new Disposable(o.callMethod("onDidBeep", [callback]));
+    return new Disposable(invoke("onDidBeep", callback));
   }
 
-  void close() {
-    o.callMethod("close");
-  }
+  void close() => invoke("close");
 
-  WindowSize get size => new WindowSize.fromJS(o.callMethod("getSize"));
+  WindowSize get size => new WindowSize.fromJS(invoke("getSize"));
   set size(WindowSize size) {
-    o.callMethod("setSize", [size.width, size.height]);
+    invoke("setSize", size.width, size.height);
   }
 
-  Position get position => new Position.fromJS(o.callMethod("getPosition"));
+  Position get position => new Position.fromJS(invoke("getPosition"));
   set position(Position pos) {
-    o.callMethod("setPosition", [pos.x, pos.y]);
+    invoke("setPosition", pos.x, pos.y);
   }
 
-  void beep() {
-    o.callMethod("beep");
-  }
+  void beep() => invoke("beep");
 
   int confirm(String message, {String detailedMessage, buttons}) {
     if (buttons != null) {
@@ -171,49 +157,46 @@ class Atom {
       }
     }
 
-    return o.callMethod("confirm", [
+    return invoke("confirm",
       omap({
         "message": message,
         "detailedMessage": detailedMessage,
         "buttons": buttons
       })
-    ]);
+    );
   }
 
-  bool get isDevMode => o.callMethod("isDevMode");
-  bool get isSafeMode => o.callMethod("isSafeMode");
-  bool get isSpecMode => o.callMethod("isSpecMode");
+  bool get isDevMode => invoke("isDevMode");
+  bool get isSafeMode => invoke("isSafeMode");
+  bool get isSpecMode => invoke("isSpecMode");
 
-  String get version => o.callMethod("getVersion");
-  bool get isReleasedVersion => o.callMethod("isReleasedVersion");
+  String get version => invoke("getVersion");
+  bool get isReleasedVersion => invoke("isReleasedVersion");
 
-  num get windowLoadTime => o.callMethod("getWindowLoadTime");
+  num get windowLoadTime => invoke("getWindowLoadTime");
 
-  void openDevTools() => o.callMethod("openDevTools");
-  void toggleDevTools() => o.callMethod("toggleDevTools");
+  void openDevTools() => invoke("openDevTools");
+  void toggleDevTools() => invoke("toggleDevTools");
   void executeJavaScriptInDevTools(String code) =>
-      o.callMethod("executeJavaScriptInDevTools", [code]);
+      invoke("executeJavaScriptInDevTools", code);
 
-  void show() => o.callMethod("show");
-  void hide() => o.callMethod("hide");
-  void center() => o.callMethod("center");
-  void reload() => o.callMethod("reload");
-  bool get isMaximized => o.callMethod("isMaximized");
-  bool get isFullscreen => o.callMethod("isFullscreen");
-  set isFullscreen(bool value) => o.callMethod("setFullscreen", [value]);
-  bool toggleFullscreen() => o.callMethod("toggleFullscreen");
+  void show() => invoke("show");
+  void hide() => invoke("hide");
+  void center() => invoke("center");
+  void reload() => invoke("reload");
+  bool get isMaximized => invoke("isMaximized");
+  bool get isFullscreen => invoke("isFullscreen");
+  set isFullscreen(bool value) => invoke("setFullscreen", value);
+  bool toggleFullscreen() => invoke("toggleFullscreen");
 }
 
 final Console console = new Console();
 
-class Console {
-  void log(String text) {
-    js.context["console"].callMethod("log", [text]);
-  }
+class Console extends ProxyHolder {
+  Console() : super(global["console"]);
 
-  void error(String text) {
-    js.context["console"].callMethod("error", [text]);
-  }
+  void log(String text) => invoke("log", text);
+  void error(String text) => invoke("error", text);
 }
 
 class WindowSize {
@@ -232,12 +215,8 @@ class Position {
   Position.fromJS(js.JsObject obj) : this(obj["x"], obj["y"]);
 }
 
-class Disposable {
-  final js.JsObject obj;
+class Disposable extends ProxyHolder {
+  Disposable(js.JsObject obj) : super(obj);
 
-  Disposable(this.obj);
-
-  void dispose() {
-    obj.callMethod("dispose");
-  }
+  void dispose() => invoke("dispose");
 }

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -157,13 +157,11 @@ class Atom extends ProxyHolder {
       }
     }
 
-    return invoke("confirm",
-      omap({
-        "message": message,
-        "detailedMessage": detailedMessage,
-        "buttons": buttons
-      })
-    );
+    return invoke("confirm", omap({
+      "message": message,
+      "detailedMessage": detailedMessage,
+      "buttons": buttons
+    }));
   }
 
   bool get isDevMode => invoke("isDevMode");

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -68,7 +68,7 @@ class ModuleExports {
   dynamic get(name) => obj[name.toString()];
 
   js.JsObject get config => obj["config"];
-  set config(input) => obj["config"] = toJsObject(input);
+  set config(input) => obj["config"] = jsify(input);
 
   operator [](name) {
     return get(name);
@@ -94,7 +94,7 @@ class Clipboard {
       new ClipboardContent(obj["text"], obj["metadata"]);
 
   void write(String text, [Map metadata = const {}]) {
-    var j = toJsObject(metadata);
+    var j = jsify(metadata);
 
     obj.callMethod("write", [text, j]);
   }

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -90,7 +90,8 @@ class Clipboard {
   Clipboard(this.obj);
 
   String read() => obj.callMethod("read");
-  ClipboardContent readWithMetadata() => new ClipboardContent(obj["text"], obj["metadata"]);
+  ClipboardContent readWithMetadata() =>
+      new ClipboardContent(obj["text"], obj["metadata"]);
 
   void write(String text, [Map metadata = const {}]) {
     var j = toJsObject(metadata);
@@ -124,7 +125,8 @@ class Atom {
   ContextMenuManager contextMenu;
   TooltipManager tooltips;
   Project get project => new Project(o["project"]);
-  NotificationManager get notifications => new NotificationManager(o['notifications']);
+  NotificationManager get notifications =>
+      new NotificationManager(o['notifications']);
 
   void open(List<String> paths, {bool newWindow, bool devMode, bool safeMode}) {
     var opts = omap({
@@ -164,7 +166,8 @@ class Atom {
   int confirm(String message, {String detailedMessage, buttons}) {
     if (buttons != null) {
       if (buttons is! List<String> && buttons is! Map<String, Function>) {
-        throw new ArgumentError.value(buttons, "buttons", "Should be either a List<String> or a Map<String, Function>");
+        throw new ArgumentError.value(buttons, "buttons",
+            "Should be either a List<String> or a Map<String, Function>");
       }
     }
 
@@ -188,7 +191,8 @@ class Atom {
 
   void openDevTools() => o.callMethod("openDevTools");
   void toggleDevTools() => o.callMethod("toggleDevTools");
-  void executeJavaScriptInDevTools(String code) => o.callMethod("executeJavaScriptInDevTools", [code]);
+  void executeJavaScriptInDevTools(String code) =>
+      o.callMethod("executeJavaScriptInDevTools", [code]);
 
   void show() => o.callMethod("show");
   void hide() => o.callMethod("hide");

--- a/lib/src/grammars.dart
+++ b/lib/src/grammars.dart
@@ -31,11 +31,16 @@ class GrammarRegistry {
 
   GrammarRegistry(this.obj);
 
-  List<Grammar> get grammars => obj.callMethod("getGrammars").map((it) => new Grammar(it)).toList();
-  Grammar grammarForScopeName(String scope) => new Grammar(obj.callMethod("grammarForScopeName", [scope]));
-  Grammar selectGrammar(String path, String content) => new Grammar(obj.callMethod("selectGrammar", [path, content]));
-  Disposable addGrammar(Grammar grammar) => new Disposable(obj.callMethod("addGrammar", [grammar.obj]));
-  Grammar readGrammarSync(String path) => new Grammar(obj.callMethod("readGrammarSync", [path]));
+  List<Grammar> get grammars =>
+      obj.callMethod("getGrammars").map((it) => new Grammar(it)).toList();
+  Grammar grammarForScopeName(String scope) =>
+      new Grammar(obj.callMethod("grammarForScopeName", [scope]));
+  Grammar selectGrammar(String path, String content) =>
+      new Grammar(obj.callMethod("selectGrammar", [path, content]));
+  Disposable addGrammar(Grammar grammar) =>
+      new Disposable(obj.callMethod("addGrammar", [grammar.obj]));
+  Grammar readGrammarSync(String path) =>
+      new Grammar(obj.callMethod("readGrammarSync", [path]));
   void readGrammar(String path, void callback(Grammar grammar)) {
     obj.callMethod("readGrammar", [path, (e, g) => callback(new Grammar(g))]);
   }
@@ -53,7 +58,8 @@ class GrammarRegistry {
   }
 
   Grammar setGrammarOverrideForPath(String path, String scope) {
-    return new Grammar(obj.callMethod("setGrammarOverrideForPath", [path, scope]));
+    return new Grammar(
+        obj.callMethod("setGrammarOverrideForPath", [path, scope]));
   }
 
   void clearGrammarOverrideForPath(String path) {

--- a/lib/src/keymap.dart
+++ b/lib/src/keymap.dart
@@ -6,7 +6,7 @@ class KeymapManager {
   KeymapManager(this.obj);
 
   void add(String selector, Map<String, Map<String, String>> bindings) {
-    var o = toJsObject(bindings);
+    var o = jsify(bindings);
 
     obj.callMethod("add", [selector, o]);
   }

--- a/lib/src/menu.dart
+++ b/lib/src/menu.dart
@@ -6,12 +6,10 @@ class Menu {
   final String command;
 
   Menu(this.label, {this.command}) : submenu = [];
-  Menu.fromJS(js.JsObject obj) :
-    label = obj["label"],
-    command = obj["command"],
-    submenu = (
-      obj["submenu"] == null ? null : fromArray(obj["submenu"])
-    );
+  Menu.fromJS(js.JsObject obj)
+      : label = obj["label"],
+        command = obj["command"],
+        submenu = (obj["submenu"] == null ? null : fromArray(obj["submenu"]));
 
   static List<Menu> fromArray(List<js.JsObject> objs) {
     return objs.map((it) => new Menu.fromJS(it)).toList();

--- a/lib/src/notification_manager.dart
+++ b/lib/src/notification_manager.dart
@@ -1,7 +1,6 @@
 part of atom;
 
 class NotificationManager {
-
   final js.JsObject obj;
 
   NotificationManager(this.obj);
@@ -37,5 +36,4 @@ class NotificationManager {
     var optionsJsObj = new js.JsObject.jsify(options);
     obj.callMethod('addFatalError', [message, optionsJsObj]);
   }
-
 }

--- a/lib/src/notification_manager.dart
+++ b/lib/src/notification_manager.dart
@@ -9,7 +9,8 @@ class NotificationManager {
   // Stream get onDidAddNotification;
 
   // Getting Notifications
-  void get notifications => obj.callMethod('getNotifications', []);
+  // TODO: What should this return?
+  dynamic get notifications => obj.callMethod('getNotifications', []);
 
   // Adding Notifications
   void addSuccess(String message, Map options) {

--- a/lib/src/notification_manager.dart
+++ b/lib/src/notification_manager.dart
@@ -14,27 +14,27 @@ class NotificationManager {
 
   // Adding Notifications
   void addSuccess(String message, Map options) {
-    var optionsJsObj = new js.JsObject.jsify(options);
+    var optionsJsObj = jsify(options);
     obj.callMethod('addSuccess', [message, optionsJsObj]);
   }
 
   void addInfo(String message, Map options) {
-    var optionsJsObj = new js.JsObject.jsify(options);
+    var optionsJsObj = jsify(options);
     obj.callMethod('addInfo', [message, optionsJsObj]);
   }
 
   void addWarning(String message, Map options) {
-    var optionsJsObj = new js.JsObject.jsify(options);
+    var optionsJsObj = jsify(options);
     obj.callMethod('addWarning', [message, optionsJsObj]);
   }
 
   void addError(String message, Map options) {
-    var optionsJsObj = new js.JsObject.jsify(options);
+    var optionsJsObj = jsify(options);
     obj.callMethod('addError', [message, optionsJsObj]);
   }
 
   void addFatalError(String message, Map options) {
-    var optionsJsObj = new js.JsObject.jsify(options);
+    var optionsJsObj = jsify(options);
     obj.callMethod('addFatalError', [message, optionsJsObj]);
   }
 }

--- a/lib/src/notification_manager.dart
+++ b/lib/src/notification_manager.dart
@@ -1,9 +1,7 @@
 part of atom;
 
-class NotificationManager {
-  final js.JsObject obj;
-
-  NotificationManager(this.obj);
+class NotificationManager extends ProxyHolder {
+  NotificationManager(js.JsObject obj) : super(obj);
 
   // Events
   // Stream get onDidAddNotification;
@@ -14,27 +12,22 @@ class NotificationManager {
 
   // Adding Notifications
   void addSuccess(String message, Map options) {
-    var optionsJsObj = jsify(options);
-    obj.callMethod('addSuccess', [message, optionsJsObj]);
+    invoke('addSuccess', message, options);
   }
 
   void addInfo(String message, Map options) {
-    var optionsJsObj = jsify(options);
-    obj.callMethod('addInfo', [message, optionsJsObj]);
+    invoke('addInfo', message, options);
   }
 
   void addWarning(String message, Map options) {
-    var optionsJsObj = jsify(options);
-    obj.callMethod('addWarning', [message, optionsJsObj]);
+    invoke('addWarning', message, options);
   }
 
   void addError(String message, Map options) {
-    var optionsJsObj = jsify(options);
-    obj.callMethod('addError', [message, optionsJsObj]);
+    invoke('addError', message, options);
   }
 
   void addFatalError(String message, Map options) {
-    var optionsJsObj = jsify(options);
-    obj.callMethod('addFatalError', [message, optionsJsObj]);
+    invoke('addFatalError', message, options);
   }
 }

--- a/lib/src/packages.dart
+++ b/lib/src/packages.dart
@@ -28,7 +28,10 @@ class PackageManager {
     return obj.callMethod("isPackageLoaded", [name]);
   }
 
-  List<String> get availablePackagePaths => obj.callMethod("getAvailablePackagePath");
-  List<String> get availablePackageNames => obj.callMethod("getAvailablePackageNames");
-  List<String> get availablePackageMetadata => obj.callMethod("getAvailablePackageMetadata");
+  List<String> get availablePackagePaths =>
+      obj.callMethod("getAvailablePackagePath");
+  List<String> get availablePackageNames =>
+      obj.callMethod("getAvailablePackageNames");
+  List<String> get availablePackageMetadata =>
+      obj.callMethod("getAvailablePackageMetadata");
 }

--- a/lib/src/pane.dart
+++ b/lib/src/pane.dart
@@ -44,20 +44,19 @@ class Pane {
   }
 
   Disposable onDidAddItem(Consumer<PaneItemAddRemoveEvent> callback) {
-    return new Disposable(obj.callMethod("onDidAddItem", [
-      (e) => callback(new PaneItemAddRemoveEvent(e["item"], e["index"]))
-    ]));
+    return new Disposable(obj.callMethod("onDidAddItem",
+        [(e) => callback(new PaneItemAddRemoveEvent(e["item"], e["index"]))]));
   }
 
   Disposable onDidRemoveItem(Consumer<PaneItemAddRemoveEvent> callback) {
-    return new Disposable(obj.callMethod("onDidRemoveItem", [
-        (e) => callback(new PaneItemAddRemoveEvent(e["item"], e["index"]))
-    ]));
+    return new Disposable(obj.callMethod("onDidRemoveItem",
+        [(e) => callback(new PaneItemAddRemoveEvent(e["item"], e["index"]))]));
   }
 
   Disposable onDidMoveItem(Consumer<PaneItemMoveEvent> callback) {
     return new Disposable(obj.callMethod("onDidMoveItem", [
-        (e) => callback(new PaneItemMoveEvent(e["item"], e["oldIndex"], e["newIndex"]))
+      (e) => callback(
+          new PaneItemMoveEvent(e["item"], e["oldIndex"], e["newIndex"]))
     ]));
   }
 
@@ -75,7 +74,7 @@ class Pane {
 
   Disposable onWillDestroyItem(Consumer<PaneItemWillDestroyEvent> callback) {
     return new Disposable(obj.callMethod("onWillDestroyItem", [
-        (e) => callback(new PaneItemWillDestroyEvent(e["item"], e["index"]))
+      (e) => callback(new PaneItemWillDestroyEvent(e["item"], e["index"]))
     ]));
   }
 
@@ -174,30 +173,22 @@ class Pane {
   void destroy() => obj.callMethod("destroy");
 
   Pane splitLeft({List<dynamic> items, bool copyActiveItem}) {
-    return new Pane(obj.callMethod("splitLeft", [toJsObject({
-      "items": items,
-      "copyActiveItem": copyActiveItem
-    })]));
+    return new Pane(obj.callMethod("splitLeft",
+        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 
   Pane splitRight({List<dynamic> items, bool copyActiveItem}) {
-    return new Pane(obj.callMethod("splitRight", [toJsObject({
-      "items": items,
-      "copyActiveItem": copyActiveItem
-    })]));
+    return new Pane(obj.callMethod("splitRight",
+        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 
   Pane splitUp({List<dynamic> items, bool copyActiveItem}) {
-    return new Pane(obj.callMethod("splitUp", [toJsObject({
-      "items": items,
-      "copyActiveItem": copyActiveItem
-    })]));
+    return new Pane(obj.callMethod("splitUp",
+        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 
   Pane splitDown({List<dynamic> items, bool copyActiveItem}) {
-    return new Pane(obj.callMethod("splitUp", [toJsObject({
-      "items": items,
-      "copyActiveItem": copyActiveItem
-    })]));
+    return new Pane(obj.callMethod("splitUp",
+        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 }

--- a/lib/src/pane.dart
+++ b/lib/src/pane.dart
@@ -174,21 +174,21 @@ class Pane {
 
   Pane splitLeft({List<dynamic> items, bool copyActiveItem}) {
     return new Pane(obj.callMethod("splitLeft",
-        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
+        [jsify({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 
   Pane splitRight({List<dynamic> items, bool copyActiveItem}) {
     return new Pane(obj.callMethod("splitRight",
-        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
+        [jsify({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 
   Pane splitUp({List<dynamic> items, bool copyActiveItem}) {
     return new Pane(obj.callMethod("splitUp",
-        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
+        [jsify({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 
   Pane splitDown({List<dynamic> items, bool copyActiveItem}) {
     return new Pane(obj.callMethod("splitUp",
-        [toJsObject({"items": items, "copyActiveItem": copyActiveItem})]));
+        [jsify({"items": items, "copyActiveItem": copyActiveItem})]));
   }
 }

--- a/lib/src/process.dart
+++ b/lib/src/process.dart
@@ -6,16 +6,9 @@ typedef void ExitCodeHandler(int exitCode);
 class BufferedProcess {
   final js.JsObject obj;
 
-  factory BufferedProcess(String command, List<String> args, {
-    Map options,
-    StdioHandler stdout,
-    StdioHandler stderr,
-    ExitCodeHandler exit
-  }) {
-    var map = {
-      "command": command,
-      "args": args
-    };
+  factory BufferedProcess(String command, List<String> args, {Map options,
+      StdioHandler stdout, StdioHandler stderr, ExitCodeHandler exit}) {
+    var map = {"command": command, "args": args};
 
     if (stdout != null) {
       map["stdout"] = stdout;
@@ -35,7 +28,8 @@ class BufferedProcess {
 
     var jsBufferedProcess = require('atom')['BufferedProcess'];
 
-    return new BufferedProcess.wrap(new js.JsObject(jsBufferedProcess, [new js.JsObject.jsify(map)]));
+    return new BufferedProcess.wrap(
+        new js.JsObject(jsBufferedProcess, [new js.JsObject.jsify(map)]));
   }
 
   BufferedProcess.wrap(this.obj);

--- a/lib/src/project.dart
+++ b/lib/src/project.dart
@@ -19,7 +19,9 @@ class Project {
     var dirs = await getDirectories();
 
     var dirobjs = dirs.map((it) => it.obj).toList();
-    var objs = await promiseToFuture(Promise.all(dirobjs.map((it) => obj.callMethod("repositoryForDirectory", [it])).toList()));
+    var objs = await promiseToFuture(Promise.all(dirobjs
+        .map((it) => obj.callMethod("repositoryForDirectory", [it]))
+        .toList()));
 
     return objs.map((it) => new GitRepository(it)).toList();
   }
@@ -45,20 +47,28 @@ class GitRepository {
   bool get hasBranch => obj.callMethod("hasBranch");
   String getShortHead(String path) => obj.callMethod("getShortHead", [path]);
   bool isSubmodule(String path) => obj.callMethod("isSubmodule", [path]);
-  int getAheadBehindCount(String ref, String path) => obj.callMethod("getAheadBehindCount", [ref, path]);
-  int getCachedUpstreamAheadBehindCount(String path) => obj.callMethod("getCachedUpstreamAheadBehindCount", [path]);
-  dynamic getConfigValue(String path) => obj.callMethod("getConfigValue", [path]);
+  int getAheadBehindCount(String ref, String path) =>
+      obj.callMethod("getAheadBehindCount", [ref, path]);
+  int getCachedUpstreamAheadBehindCount(String path) =>
+      obj.callMethod("getCachedUpstreamAheadBehindCount", [path]);
+  dynamic getConfigValue(String path) =>
+      obj.callMethod("getConfigValue", [path]);
   String getOriginUrl([String path]) => obj.callMethod("getOriginURL", [path]);
-  String getUpstreamBranch(String path) => obj.callMethod("getUpstreamBranch", [path]);
-  GitReferences getReferences(String path) => new GitReferences(obj.callMethod("getReferences", [path]));
+  String getUpstreamBranch(String path) =>
+      obj.callMethod("getUpstreamBranch", [path]);
+  GitReferences getReferences(String path) =>
+      new GitReferences(obj.callMethod("getReferences", [path]));
 
   bool isPathModified(String path) => obj.callMethod("isPathModified", [path]);
   bool isPathNew(String path) => obj.callMethod("isPathNew", [path]);
   bool isPathIgnored(String path) => obj.callMethod("isPathIgnored", [path]);
-  int getDirectoryStatus(String path) => obj.callMethod("getDirectoryStatus", [path]);
+  int getDirectoryStatus(String path) =>
+      obj.callMethod("getDirectoryStatus", [path]);
   int getPathStatus(String path) => obj.callMethod("getPathStatus", [path]);
-  int getCachedPathStatus(String path) => obj.callMethod("getCachedPathStatus", [path]);
-  bool isStatusModified(int status) => obj.callMethod("isStatusModified", [status]);
+  int getCachedPathStatus(String path) =>
+      obj.callMethod("getCachedPathStatus", [path]);
+  bool isStatusModified(int status) =>
+      obj.callMethod("isStatusModified", [status]);
   bool isStatusNew(int status) => obj.callMethod("isStatusNew", [status]);
   bool checkoutHead(String path) => obj.callMethod("checkoutHead", [path]);
   bool checkoutReference(String reference, [bool create = true]) {

--- a/lib/src/styles.dart
+++ b/lib/src/styles.dart
@@ -6,5 +6,4 @@ class StyleManager {
   StyleManager(this.obj);
 
   String get userStyleSheetPath => obj.callMethod("getUserStyleSheetPath");
-
 }

--- a/lib/src/text_editor.dart
+++ b/lib/src/text_editor.dart
@@ -20,11 +20,14 @@ class TextEditor {
   int get screenLineCount => obj.callMethod("getScreenLineCount");
   int get lastScreenRow => obj.callMethod("getLastScreenRow");
 
-  String lineTextForBufferRow(int row) => obj.callMethod("lineTextForBufferRow", [row]);
-  String lineTextForScreenRow(int row) => obj.callMethod("lineTextForScreenRow", [row]);
+  String lineTextForBufferRow(int row) =>
+      obj.callMethod("lineTextForBufferRow", [row]);
+  String lineTextForScreenRow(int row) =>
+      obj.callMethod("lineTextForScreenRow", [row]);
 
   set text(value) => obj.callMethod("setText", [value.toString()]);
-  void setTextInBufferRange(Range range, String text) => obj.callMethod("setTextInBufferRange", [
+  void setTextInBufferRange(Range range, String text) => obj.callMethod(
+      "setTextInBufferRange", [
     [range.start.row, range.start.column],
     [range.end.row, range.end.column]
   ]);
@@ -41,12 +44,18 @@ class TextEditor {
 
   String get selectedText => obj.callMethod("getSelectedText");
 
-  Disposable onDidChange(Action callback) => new Disposable(obj.callMethod("onDidChange", [callback]));
-  Disposable onDidChangePath(Action callback) => new Disposable(obj.callMethod("onDidChangePath", [callback]));
-  Disposable onDidChangeTitle(Action callback) => new Disposable(obj.callMethod("onDidChangeTitle", [callback]));
-  Disposable onDidStopChanging(Action callback) => new Disposable(obj.callMethod("onDidStopChanging", [callback]));
-  Disposable onDidSave(Action callback) => new Disposable(obj.callMethod("onDidSave", [(e) => callback()]));
-  Disposable onDidDestroy(Action callback) => new Disposable(obj.callMethod("onDidDestroy", [callback]));
+  Disposable onDidChange(Action callback) =>
+      new Disposable(obj.callMethod("onDidChange", [callback]));
+  Disposable onDidChangePath(Action callback) =>
+      new Disposable(obj.callMethod("onDidChangePath", [callback]));
+  Disposable onDidChangeTitle(Action callback) =>
+      new Disposable(obj.callMethod("onDidChangeTitle", [callback]));
+  Disposable onDidStopChanging(Action callback) =>
+      new Disposable(obj.callMethod("onDidStopChanging", [callback]));
+  Disposable onDidSave(Action callback) =>
+      new Disposable(obj.callMethod("onDidSave", [(e) => callback()]));
+  Disposable onDidDestroy(Action callback) =>
+      new Disposable(obj.callMethod("onDidDestroy", [callback]));
 
   void save() {
     obj.callMethod("save");
@@ -104,52 +113,55 @@ class TextEditor {
   set encoding(String name) => obj.callMethod("setEncoding", [name]);
 
   Disposable onDidAddCursor(Consumer<Cursor> callback) {
-    return new Disposable(obj.callMethod("onDidAddCursor", [
-        (e) => callback(new Cursor(e))
-    ]));
+    return new Disposable(
+        obj.callMethod("onDidAddCursor", [(e) => callback(new Cursor(e))]));
   }
 
   Disposable onDidRemoveCursor(Consumer<Cursor> callback) {
-    return new Disposable(obj.callMethod("onDidRemoveCursor", [
-        (e) => callback(new Cursor(e))
-    ]));
+    return new Disposable(
+        obj.callMethod("onDidRemoveCursor", [(e) => callback(new Cursor(e))]));
   }
 
   Disposable onWillInsertText(Consumer<WillInsertTextEvent> callback) {
-    return new Disposable(obj.callMethod("onWillInsertText", [
-      (e) => callback(new WillInsertTextEvent(e))
-    ]));
+    return new Disposable(obj.callMethod(
+        "onWillInsertText", [(e) => callback(new WillInsertTextEvent(e))]));
   }
 
-  Disposable onDidConflict(Action callback) => new Disposable(obj.callMethod("onDidConflict", [callback]));
-  Disposable onDidInsertText(Consumer<DidInsertTextEvent> callback) => new Disposable(obj.callMethod("onDidInsertText", [
-    (e) => new DidInsertTextEvent(e)
-  ]));
+  Disposable onDidConflict(Action callback) =>
+      new Disposable(obj.callMethod("onDidConflict", [callback]));
+  Disposable onDidInsertText(
+      Consumer<DidInsertTextEvent> callback) => new Disposable(
+      obj.callMethod("onDidInsertText", [(e) => new DidInsertTextEvent(e)]));
 
   Disposable onDidChangeGrammar(Consumer<Grammar> callback) {
-    return new Disposable(obj.callMethod("onDidChangeGrammar", [(e) => callback(new Grammar(e))]));
+    return new Disposable(obj.callMethod(
+        "onDidChangeGrammar", [(e) => callback(new Grammar(e))]));
   }
 
   Disposable onDidAddSelection(Consumer<Selection> callback) {
-    return new Disposable(obj.callMethod("onDidAddSelection", [(e) => callback(new Selection(e))]));
+    return new Disposable(obj.callMethod(
+        "onDidAddSelection", [(e) => callback(new Selection(e))]));
   }
 
   Disposable onDidRemoveSelection(Consumer<Selection> callback) {
-    return new Disposable(obj.callMethod("onDidRemoveSelection", [(e) => callback(new Selection(e))]));
+    return new Disposable(obj.callMethod(
+        "onDidRemoveSelection", [(e) => callback(new Selection(e))]));
   }
 
-  ScopeDescriptor get rootScopeDescriptor => new ScopeDescriptor.wrap(obj.callMethod("getRootScopeDescriptor"));
+  ScopeDescriptor get rootScopeDescriptor =>
+      new ScopeDescriptor.wrap(obj.callMethod("getRootScopeDescriptor"));
   ScopeDescriptor scopeDescriptorForBufferPosition(f) =>
-    new ScopeDescriptor.wrap(obj.callMethod("scopeDescriptorForBufferPosition", [f is Point ? f.toJS() : f]));
+      new ScopeDescriptor.wrap(obj.callMethod(
+          "scopeDescriptorForBufferPosition", [f is Point ? f.toJS() : f]));
 
   Disposable observeGrammar(Consumer<Grammar> callback) {
-    return new Disposable(obj.callMethod("observeGrammar", [(e) => callback(new Grammar(e))]));
+    return new Disposable(
+        obj.callMethod("observeGrammar", [(e) => callback(new Grammar(e))]));
   }
 
   Disposable observeCursors(Consumer<Cursor> callback) {
-    return new Disposable(obj.callMethod("observeCursors", [
-        (e) => callback(new Cursor(e))
-    ]));
+    return new Disposable(
+        obj.callMethod("observeCursors", [(e) => callback(new Cursor(e))]));
   }
 
   bool get isSoftWrapped => obj.callMethod("isSoftWrapped");
@@ -217,7 +229,8 @@ class TextEditor {
   void unfoldAll() => obj.callMethod("unfoldAll");
 
   String get placeholderText => obj.callMethod("getPlaceholderText");
-  set placeholderText(String text) => obj.callMethod("setPlaceholderText", [text]);
+  set placeholderText(String text) =>
+      obj.callMethod("setPlaceholderText", [text]);
 
   void scrollToTop() {
     obj.callMethod("scrollToTop");
@@ -229,11 +242,15 @@ class TextEditor {
 
   bool get hasMultipleCursors => obj.callMethod("hasMultipleCursors");
 
-  Point get cursorBufferPosition => new Point.fromJS(obj.callMethod("getCursorBufferPosition"));
-  List<Point> get cursorBufferPositions =>
-    obj.callMethod("getCursorBufferPositions").map((it) => new Position.fromJS(it)).toList();
+  Point get cursorBufferPosition =>
+      new Point.fromJS(obj.callMethod("getCursorBufferPosition"));
+  List<Point> get cursorBufferPositions => obj
+      .callMethod("getCursorBufferPositions")
+      .map((it) => new Position.fromJS(it))
+      .toList();
 
-  List<Cursor> get cursors => obj.callMethod("getCursors").map((it) => new Cursor(it)).toList();
+  List<Cursor> get cursors =>
+      obj.callMethod("getCursors").map((it) => new Cursor(it)).toList();
   Cursor get lastCursor => new Cursor(obj.callMethod("getLastCursor"));
 
   void moveUp([int lineCount]) {
@@ -268,33 +285,29 @@ class TextEditor {
     obj.callMethod("moveToBottom");
   }
 
-  Selection get lastSelection => new Selection(obj.callMethod("getLastSelection"));
-  List<Selection> get selections => obj.callMethod("getSelections").map((it) =>
-    new Selection(it)
-  ).toList();
+  Selection get lastSelection =>
+      new Selection(obj.callMethod("getLastSelection"));
+  List<Selection> get selections =>
+      obj.callMethod("getSelections").map((it) => new Selection(it)).toList();
 
   Disposable observeDecorations(Consumer<Decoration> callback) {
-    return new Disposable(obj.callMethod("observeDecorations", [
-      (e) => callback(new Decoration(e))
-    ]));
+    return new Disposable(obj.callMethod(
+        "observeDecorations", [(e) => callback(new Decoration(e))]));
   }
 
   Disposable onDidAddDecoration(Consumer<Decoration> callback) {
-    return new Disposable(obj.callMethod("onDidAddDecoration", [
-      (e) => callback(new Decoration(e))
-    ]));
+    return new Disposable(obj.callMethod(
+        "onDidAddDecoration", [(e) => callback(new Decoration(e))]));
   }
 
   Disposable onDidRemoveDecoration(Consumer<Decoration> callback) {
-    return new Disposable(obj.callMethod("onDidRemoveDecoration", [
-        (e) => callback(new Decoration(e))
-    ]));
+    return new Disposable(obj.callMethod(
+        "onDidRemoveDecoration", [(e) => callback(new Decoration(e))]));
   }
 
   Disposable onDidChangePlaceholderText(Consumer<String> callback) {
-    return new Disposable(obj.callMethod("onDidChangePlaceholderText", [
-      (e) => callback(e)
-    ]));
+    return new Disposable(
+        obj.callMethod("onDidChangePlaceholderText", [(e) => callback(e)]));
   }
 }
 
@@ -309,37 +322,29 @@ class Selection {
 
   Range get screenRange => new RangeProxy(obj.callMethod("getScreenRange"));
   Range get bufferRange => new RangeProxy(obj.callMethod("getBufferRange"));
-  void setScreenRange(Range range, {bool preserveFolds, bool autoScroll}) => obj.callMethod("setScreenRange", [
-    [
-      [range.start.row, range.start.column],
-      [range.end.row, range.end.column]
-    ],
-    omap({
-      "preserveFolds": preserveFolds,
-      "autoScroll": autoScroll
-    })
+  void setScreenRange(Range range, {bool preserveFolds, bool autoScroll}) => obj
+      .callMethod("setScreenRange", [
+    [[range.start.row, range.start.column], [range.end.row, range.end.column]],
+    omap({"preserveFolds": preserveFolds, "autoScroll": autoScroll})
   ]);
 
-  void setBufferRange(Range range, {bool preserveFolds, bool autoScroll}) => obj.callMethod("setScreenRange", [
-    [
-      [range.start.row, range.start.column],
-      [range.end.row, range.end.column]
-    ],
-    omap({
-      "preserveFolds": preserveFolds,
-      "autoScroll": autoScroll
-    })
+  void setBufferRange(Range range, {bool preserveFolds, bool autoScroll}) => obj
+      .callMethod("setScreenRange", [
+    [[range.start.row, range.start.column], [range.end.row, range.end.column]],
+    omap({"preserveFolds": preserveFolds, "autoScroll": autoScroll})
   ]);
 
   bool get isEmpty => obj.callMethod("isEmpty");
   bool get isReversed => obj.callMethod("isReversed");
   String get text => obj.callMethod("getText");
   bool get isSingleScreenLine => obj.callMethod("isSingleScreenLine");
-  bool intersectsBufferRange(Range range) => obj.callMethod("intersectsBufferRange", [
+  bool intersectsBufferRange(Range range) => obj.callMethod(
+      "intersectsBufferRange", [
     [range.start.row, range.start.column],
     [range.end.row, range.end.column]
   ]);
-  bool intersectsWith(Selection selection) => intersectsBufferRange(selection.bufferRange);
+  bool intersectsWith(Selection selection) =>
+      intersectsBufferRange(selection.bufferRange);
 
   void insertText(String text) {
     obj.callMethod("insertText", [text]);
@@ -407,7 +412,6 @@ class RangeProxy implements Range {
   @override
   bool get isSingleLine => obj.callMethod("isSingleLine");
 
-
   @override
   int get rowCount => obj.callMethod("getRowCount");
 
@@ -428,24 +432,25 @@ class Cursor {
     return new Disposable(obj.callMethod("onDidDestroy", [callback]));
   }
 
-  Disposable onDidChangePosition(Consumer<CursorPositionChangedEvent> callback) {
-    return new Disposable(obj.callMethod("onDidChangePosition", [
-      (e) => callback(new CursorPositionChangedEvent(e))
-    ]));
+  Disposable onDidChangePosition(
+      Consumer<CursorPositionChangedEvent> callback) {
+    return new Disposable(obj.callMethod("onDidChangePosition",
+        [(e) => callback(new CursorPositionChangedEvent(e))]));
   }
 
   Disposable onDidChangeVisibility(Consumer<bool> callback) {
-    return new Disposable(obj.callMethod("onDidChangeVisibility", [
-      (e) => callback(e["visibility"])
-    ]));
+    return new Disposable(obj.callMethod(
+        "onDidChangeVisibility", [(e) => callback(e["visibility"])]));
   }
 
   bool get isLastCursor => obj.callMethod("isLastCursor");
   int get indentLevel => obj.callMethod("getIndentLevel");
-  bool get isSurroundedByWhitespace => obj.callMethod("isSurroundedByWhitespace");
+  bool get isSurroundedByWhitespace =>
+      obj.callMethod("isSurroundedByWhitespace");
   bool get isBetweenWordAndNonWord => obj.callMethod("isBetweenWordAndNonWord");
   bool get isVisible => obj.callMethod("isVisible");
-  bool get hasPrecedingCharactersOnLine => obj.callMethod("hasPrecedingCharactersOnLine");
+  bool get hasPrecedingCharactersOnLine =>
+      obj.callMethod("hasPrecedingCharactersOnLine");
 
   bool get isAtBeginningOfLine => obj.callMethod("isAtBeginningOfLine");
   bool get isAtEndOfLine => obj.callMethod("isAtEndOfLine");
@@ -462,15 +467,13 @@ class Cursor {
   int get screenColumn => obj.callMethod("getScreenColumn");
 
   void setScreenPosition(int row, int column, {bool autoscroll}) {
-    obj.callMethod("setScreenPosition", [[row, column], omap({
-      "autoscroll": autoscroll
-    })]);
+    obj.callMethod(
+        "setScreenPosition", [[row, column], omap({"autoscroll": autoscroll})]);
   }
 
   void setBufferPosition(int row, int column, {bool autoscroll}) {
-    obj.callMethod("setBufferPosition", [[row, column], omap({
-      "autoscroll": autoscroll
-    })]);
+    obj.callMethod(
+        "setBufferPosition", [[row, column], omap({"autoscroll": autoscroll})]);
   }
 
   String get currentWordPrefix => obj.callMethod("getCurrentWordPrefix");
@@ -502,10 +505,7 @@ class Point {
   Point.fromJS(js.JsObject obj) : this(obj["row"], obj["column"]);
 
   js.JsObject toJS() {
-    return new js.JsObject.jsify({
-      "row": row,
-      "column": column
-    });
+    return new js.JsObject.jsify({"row": row, "column": column});
   }
 }
 
@@ -542,16 +542,21 @@ class Decoration {
     return new Disposable(obj.callMethod("onDidDestroy", [callback]));
   }
 
-  Disposable onDidChangeProperties(Consumer<DecorationPropertiesChangeEvent> callback) {
-    return new Disposable(obj.callMethod("onDidChangeProperties", [(o) {
-      return callback(new DecorationPropertiesChangeEvent(o["oldProperties"], o["newProperties"]));
-    }]));
+  Disposable onDidChangeProperties(
+      Consumer<DecorationPropertiesChangeEvent> callback) {
+    return new Disposable(obj.callMethod("onDidChangeProperties", [
+      (o) {
+        return callback(new DecorationPropertiesChangeEvent(
+            o["oldProperties"], o["newProperties"]));
+      }
+    ]));
   }
 
   get id => obj.callMethod("getId");
 
   js.JsObject get properties => obj.callMethod("getProperties");
-  set properties(js.JsObject properties) => obj.callMethod("setProperties", [properties]);
+  set properties(js.JsObject properties) =>
+      obj.callMethod("setProperties", [properties]);
 }
 
 class DecorationPropertiesChangeEvent {

--- a/lib/src/tooltips.dart
+++ b/lib/src/tooltips.dart
@@ -6,9 +6,9 @@ class TooltipManager {
   TooltipManager(this.obj);
 
   Disposable add(target, String title, {String keyBindingCommand}) {
-    return new Disposable(obj.callMethod("add", [target, omap({
-      "title": title,
-      "keyBindingCommand": keyBindingCommand
-    })]));
+    return new Disposable(obj.callMethod("add", [
+      target,
+      omap({"title": title, "keyBindingCommand": keyBindingCommand})
+    ]));
   }
 }

--- a/lib/src/workspace.dart
+++ b/lib/src/workspace.dart
@@ -97,9 +97,8 @@ class Workspace {
   }
 
   Panel _addPanel(String type, Element item, bool visible, int priority) {
-    return new Panel(obj.callMethod(type, [
-      jsify({"item": item, "visible": visible, "priority": priority})
-    ]));
+    return new Panel(obj.callMethod(type,
+        [jsify({"item": item, "visible": visible, "priority": priority})]));
   }
 
   List<Panel> _panels(String type) {

--- a/lib/src/workspace.dart
+++ b/lib/src/workspace.dart
@@ -5,14 +5,20 @@ class Workspace {
 
   Workspace(this.obj);
 
-  TextEditor get activeTextEditor => new TextEditor.wrap(obj.callMethod("getActiveTextEditor"));
-  List<TextEditor> get textEditors => obj.callMethod("getTextEditors").map((it) => new TextEditor.wrap(it)).toList();
+  TextEditor get activeTextEditor =>
+      new TextEditor.wrap(obj.callMethod("getActiveTextEditor"));
+  List<TextEditor> get textEditors => obj
+      .callMethod("getTextEditors")
+      .map((it) => new TextEditor.wrap(it))
+      .toList();
 
   Disposable observeTextEditors(Consumer<TextEditor> callback) {
-    return new Disposable(obj.callMethod("observeTextEditors", [(o) => callback(new TextEditor.wrap(o))]));
+    return new Disposable(obj.callMethod(
+        "observeTextEditors", [(o) => callback(new TextEditor.wrap(o))]));
   }
 
-  Future<TextEditor> open(String uri, {int initialLine, int initialColumn, String split, bool activatePane, bool searchAllPanes}) async {
+  Future<TextEditor> open(String uri, {int initialLine, int initialColumn,
+      String split, bool activatePane, bool searchAllPanes}) async {
     var map = omap({
       "initialLine": initialLine,
       "initialColumn": initialColumn,
@@ -21,9 +27,8 @@ class Workspace {
       "searchAllPanes": searchAllPanes
     });
 
-    return new TextEditor.wrap(await promiseToFuture(
-      obj.callMethod("open", [uri, map])
-    ));
+    return new TextEditor.wrap(
+        await promiseToFuture(obj.callMethod("open", [uri, map])));
   }
 
   Future reopenItem() => promiseToFuture(obj.callMethod("reopenItem"));
@@ -32,21 +37,22 @@ class Workspace {
   }
 
   Panel addTopPanel(Element item, {bool visible: true, int priority: 100}) =>
-    _addPanel("addTopPanel", item, visible, priority);
+      _addPanel("addTopPanel", item, visible, priority);
 
   Panel addRightPanel(Element item, {bool visible: true, int priority: 100}) =>
-    _addPanel("addRightPanel", item, visible, priority);
+      _addPanel("addRightPanel", item, visible, priority);
 
   Panel addLeftPanel(Element item, {bool visible: true, int priority: 100}) =>
-    _addPanel("addLeftPanel", item, visible, priority);
+      _addPanel("addLeftPanel", item, visible, priority);
 
   Panel addBottomPanel(Element item, {bool visible: true, int priority: 100}) =>
-    _addPanel("addBottomPanel", item, visible, priority);
+      _addPanel("addBottomPanel", item, visible, priority);
 
   Panel addModalPanel(Element item, {bool visible: true, int priority: 100}) =>
-    _addPanel("addModalPanel", item, visible, priority);
+      _addPanel("addModalPanel", item, visible, priority);
 
-  List<Pane> get panes => obj.callMethod("getPanes").map((it) => new Pane(it)).toList();
+  List<Pane> get panes =>
+      obj.callMethod("getPanes").map((it) => new Pane(it)).toList();
   Pane get activePane => new Pane(obj.callMethod("getActivePane"));
   void activateNextPane() {
     obj.callMethod("activateNextPane");
@@ -92,11 +98,7 @@ class Workspace {
 
   Panel _addPanel(String type, Element item, bool visible, int priority) {
     return new Panel(obj.callMethod(type, [
-      toJsObject({
-        "item": item,
-        "visible": visible,
-        "priority": priority
-      })
+      toJsObject({"item": item, "visible": visible, "priority": priority})
     ]));
   }
 

--- a/lib/src/workspace.dart
+++ b/lib/src/workspace.dart
@@ -98,7 +98,7 @@ class Workspace {
 
   Panel _addPanel(String type, Element item, bool visible, int priority) {
     return new Panel(obj.callMethod(type, [
-      toJsObject({"item": item, "visible": visible, "priority": priority})
+      jsify({"item": item, "visible": visible, "priority": priority})
     ]));
   }
 

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+
 import 'package:barback/barback.dart';
 
 class AtomBuildTransformer extends Transformer {

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -16,7 +16,10 @@ class AtomBuildTransformer extends Transformer {
   }
 
   String _fixScript(String input) {
-    return HEADER + "\n" + input.replaceAll(r'if (typeof document === "undefined") {', "if (true) {");
+    return HEADER +
+        "\n" +
+        input.replaceAll(
+            r'if (typeof document === "undefined") {', "if (true) {");
   }
 
   final String HEADER = """

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -9,6 +9,8 @@ Map<String, dynamic> omap(Map<String, dynamic> map) {
   return copy;
 }
 
+js.JsObject jsify(Map map) => new js.JsObject.jsify(map);
+
 Future promiseToFuture(promise) {
   if (promise is js.JsObject) {
     promise = new Promise(promise);
@@ -45,5 +47,26 @@ class Promise {
 
   void catchError(Function func) {
     obj.callMethod("catch", [func]);
+  }
+}
+
+abstract class ProxyHolder extends Object {
+  final js.JsObject obj;
+  ProxyHolder(this.obj);
+
+  dynamic invoke(String method, [dynamic arg1, dynamic arg2, dynamic arg3]) {
+    if (arg1 is Map) arg1 = jsify(arg1);
+    if (arg2 is Map) arg2 = jsify(arg2);
+    if (arg3 is Map) arg3 = jsify(arg3);
+
+    if (arg3 != null) {
+      return obj.callMethod(method, [arg1, arg2, arg3]);
+    } else if (arg2 != null) {
+      return obj.callMethod(method, [arg1, arg2]);
+    } else if (arg2 != null) {
+      return obj.callMethod(method, [arg1]);
+    } else {
+      return obj.callMethod(method);
+    }
   }
 }

--- a/test/badger.pkg.dart
+++ b/test/badger.pkg.dart
@@ -1,15 +1,11 @@
 import "package:atom/builder.dart";
 
 void main() {
-  
-  package(
-    "language-badger",
-    "0.1.0",
-    license: "MIT",
-    repository: "https://github.com/badger/atom-language-badger",
-    description: "Badger Support for Atom",
-    main: "lib/index.js"
-  ).atom(">0.180.0");
+  package("language-badger", "0.1.0",
+      license: "MIT",
+      repository: "https://github.com/badger/atom-language-badger",
+      description: "Badger Support for Atom",
+      main: "lib/index.js").atom(">0.180.0");
 
   buildBadgerGrammar();
 
@@ -23,8 +19,10 @@ void buildBadgerGrammar() {
     match("storage.modifier.badger", r"\b(let|var)\b");
 
     g.pattern(new BeginEndGrammarPattern("string.badger", '"', '"', [
-      new MatchGrammarPattern("constant.character.escape.badger", r"\\([bfnrt\\])"),
-      new MatchGrammarPattern("constant.character.escape.badger", r"\\u([0-9a-fA-F]{4})"),
+      new MatchGrammarPattern(
+          "constant.character.escape.badger", r"\\([bfnrt\\])"),
+      new MatchGrammarPattern(
+          "constant.character.escape.badger", r"\\u([0-9a-fA-F]{4})"),
       new MatchGrammarPattern("variable.parameter.badger", r"\$\((\w+)\)")
     ]));
 
@@ -33,12 +31,15 @@ void buildBadgerGrammar() {
     match("meta.delimiter.object.comma.badger", ",");
     match("storage.type.function.badger", r"(?<!\.)\b(func)(?!\s*:)\b");
     match("meta.delimiter.method.period.badger", r"\.");
-    match("constant.numeric.badger", r"\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)\b");
-    match("keyword.control.badger", r"(?<!\.)\b(for|while|if|else|return|break|switch|case)(?!\s*:)\b");
+    match("constant.numeric.badger",
+        r"\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)\b");
+    match("keyword.control.badger",
+        r"(?<!\.)\b(for|while|if|else|return|break|switch|case)(?!\s*:)\b");
     match("keyword.operator.assignment.badger", "(=)");
     match("keyword.operator.badger", r"(in|==|!=|\+|-|>|<|>=|<=|\*|\/|<<|>>)");
     match("constant.language.boolean.true.badger", r"(?<!\.)\btrue(?!\s*:)\b");
-    match("constant.language.boolean.false.badger", r"(?<!\.)\bfalse(?!\s*:)\b");
+    match(
+        "constant.language.boolean.false.badger", r"(?<!\.)\bfalse(?!\s*:)\b");
     match("support.function.badger", r"(?<!\.)\b(print|async|run)(?!\s*:)\b");
   });
 }

--- a/tool/check_api.dart
+++ b/tool/check_api.dart
@@ -14,9 +14,9 @@ void main() {
 
 Map<String, String> loadOurAPI() {
   var result = Process.runSync(
-    Platform.isWindows ? "dartdocgen.bat" : "dartdocgen",
-    "--no-include-sdk --package-root=packages --indent-json lib/atom.dart".split(" ")
-  );
+      Platform.isWindows ? "dartdocgen.bat" : "dartdocgen",
+      "--no-include-sdk --package-root=packages --indent-json lib/atom.dart"
+          .split(" "));
 
   if (result.exitCode != 0) {
     print("Failed to generate our documentation!");
@@ -69,5 +69,6 @@ class AtomClass {
 }
 
 AtomApi loadAtomAPI() {
-  return new AtomApi.fromJSON(JSON.decode(new File("tool/atom-api.json").readAsStringSync()));
+  return new AtomApi.fromJSON(
+      JSON.decode(new File("tool/atom-api.json").readAsStringSync()));
 }


### PR DESCRIPTION
Very excited to see this package! Here's a PR which:
- runs dartfmt - I did it in it's own commit to make it easier to ignore those diffs in the PR
- introduces a ProxyHolder abstract class - the parent of anything which logically owns a `JsObject` instance
- added a method on `ProxyHolder` - `invoke()` - which serves as shorthand for invoking a JS method
- converted a few classes over to using `ProxyHolder`

Feedback welcome!
