### PR TITLE
add a travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: dart
+script: ./tool/travis.sh
+sudo: false

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Fast fail the script on failures.
+set -e
+
+# Verify that the libraries are error free.
+pub global activate tuneup
+pub global run tuneup check
+
+# Run the tests.
+#dart test/all.dart


### PR DESCRIPTION
This adds the files necessary to analyze the dart source on each PR (and fail a travis build if there are any analysis errors or warnings).

You'll need to turn the project on from the travis dashboard (and will probably want to add a travis badge to the readme). Cheers!
