### PR TITLE
bug fix in config

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -12,7 +12,7 @@ class Config extends ProxyHolder {
     return invoke("get", key, defaultValue, map.isEmpty ? null : map);
   }
 
-  /// A conveinence method for [get] when it is known to return a String. This
+  /// A convenience method for [get] when it is known to return a String. This
   /// will return `null` if the return type is anything but a [String].
   String getString(String key, {dynamic defaultValue, List<String> sources,
       List<String> excludeSources, ScopeDescriptor scope}) {
@@ -22,10 +22,7 @@ class Config extends ProxyHolder {
         excludeSources: excludeSources,
         scope: scope);
     if (result is String || result == null) return result;
-    if (result is js.JsObject) {
-      window.console.log(result);
-      return result.callMethod('toString');
-    }
+    if (result is js.JsObject) return result.callMethod('toString');
     return '${result}';
   }
 

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -4,21 +4,48 @@ class Config extends ProxyHolder {
   Config(js.JsObject obj) : super(obj);
 
   dynamic get(String key, {dynamic defaultValue, List<String> sources,
-      List<String> excludeSources, ScopeDescriptor scope}) => invoke("get", key,
-          defaultValue, {
-    "sources": sources,
-    "excludeSources": excludeSources,
-    "scope": scope.obj
-  });
+      List<String> excludeSources, ScopeDescriptor scope}) {
+    Map map = {};
+    if (sources != null) map['sources'] = sources;
+    if (excludeSources != null) map['excludeSources'] = excludeSources;
+    if (scope != null) map['scope'] = scope.obj;
+    return invoke("get", key, defaultValue, map.isEmpty ? null : map);
+  }
 
-  void set(String key, dynamic value, {String scopeSelector, String source}) =>
-      invoke("set", key, value, {
-    "scopeSelector": scopeSelector,
-    "source": source
-  });
+  /// A conveinence method for [get] when it is known to return a String. This
+  /// will return `null` if the return type is anything but a [String].
+  String getString(String key, {dynamic defaultValue, List<String> sources,
+      List<String> excludeSources, ScopeDescriptor scope}) {
+    var result = get(key,
+        defaultValue: defaultValue,
+        sources: sources,
+        excludeSources: excludeSources,
+        scope: scope);
+    if (result is String || result == null) return result;
+    if (result is js.JsObject) {
+      window.console.log(result);
+      return result.callMethod('toString');
+    }
+    return '${result}';
+  }
 
-  void unset(String key, {String scopeSelector, String source}) =>
-      invoke("unset", key, {"scopeSelector": scopeSelector, "source": source});
+  void set(String key, dynamic value, {String scopeSelector, String source}) {
+    Map map = {};
+    if (scopeSelector != null) map['scopeSelector'] = scopeSelector;
+    if (source != null) map['source'] = source;
+    invoke("set", key, value, map.isEmpty ? null : map);
+  }
+
+  // TODO: observe
+
+  // TODO: onDidChange
+
+  void unset(String key, {String scopeSelector, String source}) {
+    Map map = {};
+    if (scopeSelector != null) map['scopeSelector'] = scopeSelector;
+    if (source != null) map['source'] = source;
+    invoke("unset", key, map.isEmpty ? null : map);
+  }
 }
 
 class ScopeDescriptor extends ProxyHolder {

--- a/lib/src/core.dart
+++ b/lib/src/core.dart
@@ -93,27 +93,41 @@ class Clipboard extends ProxyHolder {
 }
 
 class Atom extends ProxyHolder {
+  Workspace _workspace;
+  CommandRegistry _commands;
+  PackageManager _packages;
+  StyleManager _styles;
+  ThemeManager _themes;
+  MenuManager _menu;
+  Clipboard _clipboard;
+  ContextMenuManager _contextMenu;
+  TooltipManager _tooltips;
+  Config _config;
+
   Atom() : super(global["atom"]) {
-    workspace = new Workspace(obj["workspace"]);
-    commands = new CommandRegistry(obj["commands"]);
-    packages = new PackageManager(obj["packages"]);
-    styles = new StyleManager(obj["styles"]);
-    themes = new ThemeManager(obj["themes"]);
-    menu = new MenuManager(obj["menu"]);
-    clipboard = new Clipboard(obj["clipboard"]);
-    contextMenu = new ContextMenuManager(obj["contextMenu"]);
-    tooltips = new TooltipManager(obj["tooltips"]);
+    _workspace = new Workspace(obj["workspace"]);
+    _commands = new CommandRegistry(obj["commands"]);
+    _packages = new PackageManager(obj["packages"]);
+    _styles = new StyleManager(obj["styles"]);
+    _themes = new ThemeManager(obj["themes"]);
+    _menu = new MenuManager(obj["menu"]);
+    _clipboard = new Clipboard(obj["clipboard"]);
+    _contextMenu = new ContextMenuManager(obj["contextMenu"]);
+    _tooltips = new TooltipManager(obj["tooltips"]);
+    _config = new Config(obj["config"]);
   }
 
-  Workspace workspace;
-  CommandRegistry commands;
-  PackageManager packages;
-  StyleManager styles;
-  ThemeManager themes;
-  MenuManager menu;
-  Clipboard clipboard;
-  ContextMenuManager contextMenu;
-  TooltipManager tooltips;
+  Workspace get workspace => _workspace;
+  CommandRegistry get commands => _commands;
+  PackageManager get packages => _packages;
+  StyleManager get styles => _styles;
+  ThemeManager get themes => _themes;
+  MenuManager get menu => _menu;
+  Clipboard get clipboard => _clipboard;
+  ContextMenuManager get contextMenu => _contextMenu;
+  TooltipManager get tooltips => _tooltips;
+  Config get config => _config;
+
   Project get project => new Project(obj["project"]);
   NotificationManager get notifications =>
       new NotificationManager(obj['notifications']);

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -52,6 +52,7 @@ class Promise {
 
 abstract class ProxyHolder extends Object {
   final js.JsObject obj;
+
   ProxyHolder(this.obj);
 
   dynamic invoke(String method, [dynamic arg1, dynamic arg2, dynamic arg3]) {


### PR DESCRIPTION
- fix a bug where we were dereferencing null `scope` objects in the `Config.get()` method.
- add a convenience `Config.getString` method
- expose `atom.config`
- make the `atom` fields final

Note, I have not been able to get a String out of the `Config.get()` - it always returns as an JsObject instance. I have not been able to track down what's going on -
