### PR TITLE
patch the generated javascript to fix futures, streams

### DIFF
--- a/lib/build.dart
+++ b/lib/build.dart
@@ -150,4 +150,6 @@ self.window = window;
 self.atom = atom;
 self.exports = exports;
 self.Object = Object;
+self.setTimeout = function(f, millis) { window.setTimeout(f, millis); };
+
 """;

--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -30,5 +30,7 @@ self.window = window;
 self.atom = atom;
 self.exports = exports;
 self.Object = Object;
+self.setTimeout = function(f, millis) { window.setTimeout(f, millis); };
+
   """;
 }


### PR DESCRIPTION
This is a patch to the code that post-processes the dart2js output. It patches a `setTimeout` function into `self`. Without this, nothing asynchronous will work (futures will never complete, async streams will never fire values, ...). The only code that would run is the main method and callbacks from atom.

Fair warning, you'll want to test this in your codebase, but a similar patch got futures working for me.
